### PR TITLE
Add `_normalized` metrics for loadaverage

### DIFF
--- a/docs/collectors/LoadAverageCollector.md
+++ b/docs/collectors/LoadAverageCollector.md
@@ -26,8 +26,11 @@ simple | False | Only collect the 1 minute load average | str
 
 ```
 servers.hostname.loadavg.01 (0.12, 2)
+servers.hostname.loadavg.01_normalized (0.06, 2)
 servers.hostname.loadavg.05 (0.23, 2)
+servers.hostname.loadavg.05_normalized (0.115, 2)
 servers.hostname.loadavg.15 (0.34, 2)
+servers.hostname.loadavg.15_normalized (0.17, 2)
 servers.hostname.loadavg.processes_running 1
 servers.hostname.loadavg.processes_total 235
 ```

--- a/src/collectors/loadavg/loadavg.py
+++ b/src/collectors/loadavg/loadavg.py
@@ -12,6 +12,7 @@ Uses /proc/loadavg to collect data on load average
 import diamond.collector
 import re
 import os
+import multiprocessing
 from diamond.collector import str_to_bool
 
 
@@ -41,13 +42,18 @@ class LoadAverageCollector(diamond.collector.Collector):
 
     def collect(self):
         load01, load05, load15 = os.getloadavg()
+        cpu_count = multiprocessing.cpu_count()
 
         if not str_to_bool(self.config['simple']):
             self.publish_gauge('01', load01, 2)
             self.publish_gauge('05', load05, 2)
             self.publish_gauge('15', load15, 2)
+            self.publish_gauge('01_normalized', load01 / cpu_count, 2)
+            self.publish_gauge('05_normalized', load05 / cpu_count, 2)
+            self.publish_gauge('15_normalized', load15 / cpu_count, 2)
         else:
             self.publish_gauge('load', load01, 2)
+            self.publish_gauge('load_normalized', load01 / cpu_count, 2)
 
         # Legacy: add process/thread counters provided by
         # /proc/loadavg (if available).

--- a/src/collectors/loadavg/test/testloadavg.py
+++ b/src/collectors/loadavg/test/testloadavg.py
@@ -44,17 +44,23 @@ class TestLoadAverageCollector(CollectorTestCase):
         self.collector.collect()
         open_mock.assert_called_once_with('/proc/loadavg')
 
+    @patch('multiprocessing.cpu_count')
     @patch('os.getloadavg')
     @patch.object(Collector, 'publish')
-    def test_should_work_with_real_data(self, publish_mock, getloadavg_mock):
+    def test_should_work_with_real_data(self, publish_mock, getloadavg_mock,
+                                        cpu_count_mock):
         LoadAverageCollector.PROC_LOADAVG = self.getFixturePath('proc_loadavg')
         getloadavg_mock.return_value = (0.12, 0.23, 0.34)
+        cpu_count_mock.return_value = 2
         self.collector.collect()
 
         metrics = {
             '01': (0.12, 2),
             '05': (0.23, 2),
             '15': (0.34, 2),
+            '01_normalized': (0.06, 2),
+            '05_normalized': (0.115, 2),
+            '15_normalized': (0.17, 2),
             'processes_running': 1,
             'processes_total': 235
         }


### PR DESCRIPTION
Normalized is the load average divided by the number of CPU's
A normalized load average of 1 = all CPU's at 100% usage
